### PR TITLE
Create NutWorks bilingual marketing site

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,10 +30,15 @@
   <style>
     html { scroll-behavior: smooth; }
     body { background: #050d0a; }
-    .hero-bg {
-      background-image: linear-gradient(rgba(6,26,18,0.75), rgba(6,26,18,0.9)), url('assets/hero.png');
-      background-size: cover;
-      background-position: center;
+    .hero-section {
+      min-height: 72vh;
+    }
+    #hero3d {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
     }
     .card-gradient {
       background: linear-gradient(135deg, rgba(255,255,255,0.08) 0%, rgba(9,41,30,0.6) 100%);
@@ -81,9 +86,10 @@
   </header>
 
   <main id="home" class="pt-24">
-    <section class="hero-bg relative">
-      <div class="absolute inset-0 bg-gradient-to-b from-transparent via-brandDeep/20 to-brandDeep"></div>
-      <div class="relative max-w-6xl mx-auto px-6 py-24 md:py-32">
+    <section class="hero-section relative overflow-hidden flex items-center">
+      <canvas id="hero3d" aria-hidden="true"></canvas>
+      <div class="absolute inset-0 bg-gradient-to-b from-brandDeep/40 via-brandDeep/70 to-brandDeep z-10"></div>
+      <div class="relative z-20 w-full max-w-6xl mx-auto px-6 py-24 md:py-32">
         <div class="max-w-3xl">
           <p class="uppercase tracking-[0.35em] text-xs text-brandGold/80">Premium Cashew Brand</p>
           <h1 class="mt-6 text-4xl md:text-5xl font-heading font-semibold leading-tight">
@@ -449,6 +455,69 @@
 
     acceptCookies?.addEventListener('click', () => handleConsent('accepted'));
     closeCookies?.addEventListener('click', () => handleConsent('declined'));
+  </script>
+  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+  <script>
+    (() => {
+      const canvas = document.getElementById('hero3d');
+      if (!canvas || !window.THREE) return;
+
+      const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(45, 2, 0.1, 100);
+      camera.position.set(0, 0, 6);
+
+      const resize = () => {
+        const parent = canvas.parentElement;
+        if (!parent) return;
+        const width = parent.clientWidth;
+        const height = Math.max(parent.clientHeight, 480);
+        renderer.setSize(width, height, false);
+        camera.aspect = width / height;
+        camera.updateProjectionMatrix();
+      };
+      resize();
+      window.addEventListener('resize', resize);
+
+      const dots = 2000;
+      const positions = new Float32Array(dots * 3);
+      for (let i = 0; i < dots; i++) {
+        const u = Math.random();
+        const v = Math.random();
+        const theta = 2 * Math.PI * u;
+        const phi = Math.acos(2 * v - 1);
+        const radius = 2.1;
+        positions[i * 3] = radius * Math.sin(phi) * Math.cos(theta);
+        positions[i * 3 + 1] = radius * Math.cos(phi);
+        positions[i * 3 + 2] = radius * Math.sin(phi) * Math.sin(theta);
+      }
+
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      const material = new THREE.PointsMaterial({ size: 0.02, color: 0xD4AF37 });
+      const globe = new THREE.Points(geometry, material);
+      scene.add(globe);
+
+      const planeGeometry = new THREE.PlaneGeometry(14, 8);
+      const planeMaterial = new THREE.MeshBasicMaterial({ color: 0x041610, transparent: true, opacity: 0.7 });
+      const plane = new THREE.Mesh(planeGeometry, planeMaterial);
+      plane.position.z = -1.5;
+      scene.add(plane);
+
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+      const animate = (time) => {
+        if (!prefersReducedMotion) {
+          globe.rotation.y += 0.0018;
+          globe.rotation.x = 0.15 * Math.sin(time * 0.0003);
+        }
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        renderer.render(scene, camera);
+        requestAnimationFrame(animate);
+      };
+
+      requestAnimationFrame(animate);
+    })();
   </script>
 </body>
 </html>

--- a/index_fr.html
+++ b/index_fr.html
@@ -30,10 +30,15 @@
   <style>
     html { scroll-behavior: smooth; }
     body { background: #050d0a; }
-    .hero-bg {
-      background-image: linear-gradient(rgba(6,26,18,0.75), rgba(6,26,18,0.9)), url('assets/hero.png');
-      background-size: cover;
-      background-position: center;
+    .hero-section {
+      min-height: 72vh;
+    }
+    #hero3d {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
     }
     .card-gradient {
       background: linear-gradient(135deg, rgba(255,255,255,0.08) 0%, rgba(9,41,30,0.6) 100%);
@@ -81,9 +86,10 @@
   </header>
 
   <main id="home" class="pt-24">
-    <section class="hero-bg relative">
-      <div class="absolute inset-0 bg-gradient-to-b from-transparent via-brandDeep/20 to-brandDeep"></div>
-      <div class="relative max-w-6xl mx-auto px-6 py-24 md:py-32">
+    <section class="hero-section relative overflow-hidden flex items-center">
+      <canvas id="hero3d" aria-hidden="true"></canvas>
+      <div class="absolute inset-0 bg-gradient-to-b from-brandDeep/40 via-brandDeep/70 to-brandDeep z-10"></div>
+      <div class="relative z-20 w-full max-w-6xl mx-auto px-6 py-24 md:py-32">
         <div class="max-w-3xl">
           <p class="uppercase tracking-[0.35em] text-xs text-brandGold/80">Marque de cajou premium</p>
           <h1 class="mt-6 text-4xl md:text-5xl font-heading font-semibold leading-tight">
@@ -449,6 +455,69 @@
 
     acceptCookies?.addEventListener('click', () => handleConsent('accepted'));
     closeCookies?.addEventListener('click', () => handleConsent('declined'));
+  </script>
+  <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
+  <script>
+    (() => {
+      const canvas = document.getElementById('hero3d');
+      if (!canvas || !window.THREE) return;
+
+      const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
+      const scene = new THREE.Scene();
+      const camera = new THREE.PerspectiveCamera(45, 2, 0.1, 100);
+      camera.position.set(0, 0, 6);
+
+      const resize = () => {
+        const parent = canvas.parentElement;
+        if (!parent) return;
+        const width = parent.clientWidth;
+        const height = Math.max(parent.clientHeight, 480);
+        renderer.setSize(width, height, false);
+        camera.aspect = width / height;
+        camera.updateProjectionMatrix();
+      };
+      resize();
+      window.addEventListener('resize', resize);
+
+      const dots = 2000;
+      const positions = new Float32Array(dots * 3);
+      for (let i = 0; i < dots; i++) {
+        const u = Math.random();
+        const v = Math.random();
+        const theta = 2 * Math.PI * u;
+        const phi = Math.acos(2 * v - 1);
+        const radius = 2.1;
+        positions[i * 3] = radius * Math.sin(phi) * Math.cos(theta);
+        positions[i * 3 + 1] = radius * Math.cos(phi);
+        positions[i * 3 + 2] = radius * Math.sin(phi) * Math.sin(theta);
+      }
+
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      const material = new THREE.PointsMaterial({ size: 0.02, color: 0xD4AF37 });
+      const globe = new THREE.Points(geometry, material);
+      scene.add(globe);
+
+      const planeGeometry = new THREE.PlaneGeometry(14, 8);
+      const planeMaterial = new THREE.MeshBasicMaterial({ color: 0x041610, transparent: true, opacity: 0.7 });
+      const plane = new THREE.Mesh(planeGeometry, planeMaterial);
+      plane.position.z = -1.5;
+      scene.add(plane);
+
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+      const animate = (time) => {
+        if (!prefersReducedMotion) {
+          globe.rotation.y += 0.0018;
+          globe.rotation.x = 0.15 * Math.sin(time * 0.0003);
+        }
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        renderer.render(scene, camera);
+        requestAnimationFrame(animate);
+      };
+
+      requestAnimationFrame(animate);
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the landing page with premium NutWorks branding, hero, roadmap, products, team, and contact sections
- add a French translation page and shared responsive navigation with language toggle
- implement cookie consent banner, mobile menu toggle, and refreshed contact form styling

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dd4535b46c8330b0d75ddfba2b2639